### PR TITLE
Reallocate X to avoid negative stride errors

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -108,7 +108,7 @@ def harmonize(
         else:
             print("CUDA is not available on your machine. Use CPU mode instead.")
 
-    Z = torch.tensor(X, dtype=torch.float, device=device_type)
+    Z = torch.tensor(np.array(X), dtype=torch.float, device=device_type)
     Z_norm = normalize(Z, p=2, dim=1)
     n_cells = Z.shape[0]
 


### PR DESCRIPTION
If `X` array has negative strides I end up getting the following error:

`RuntimeError: some of the strides of a given numpy array are negative. This is currently not supported, but will be added in future releases.`

Reallocating the matrix solves this. I don't know what actually might lead to negative stride, but I got this error once.